### PR TITLE
Proposed fix for #140

### DIFF
--- a/src/LaravelViewBinder.php
+++ b/src/LaravelViewBinder.php
@@ -40,8 +40,9 @@ class LaravelViewBinder implements ViewBinder
     public function bind($js)
     {
         foreach ($this->views as $view) {
-            $this->event->listen("composing: {$view}", function () use ($js) {
+            $this->event->listen("composing: {$view}", function () use ($js, $view) {
                 echo "<script>{$js}</script>";
+                $this->event->forget("composing: {$view}");
             });
         }
     }


### PR DESCRIPTION
After the JS has been echo'd to the blade template, remove the event listener. Appears to work in our Laravel application as well as with Octane and works with multiple binds in a single request.